### PR TITLE
fix issues with minio starting on Render.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ Click the button below to deploy MinIO to your Render account:
 [![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://dashboard.render.com/iac/new?repoOwner=render-examples&repoName=minio&branch=master&provider=GITHUB)
 
 This will create a public MinIO instance with automatically generated access and secret keys as environment variables. You can see their values under the Environment section of your Render service.
+
+## Running Locally
+
+if you are having problems and want to debug, you can run the container locally
+
+```bash
+docker build -t minio .
+docker run -p 9000:9000 -p 9001:9001 -e MINIO_ROOT_USER=admin -e MINIO_ROOT_PASSWORD=secretpwd minio
+```
+
+then take your browser and go to [http://localhost:9000](http://localhost:9000) and login with the credentials used in the docker run command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 # wrapper for docker entrypoint that takes into account the PORT env var
 
-exec docker-entrypoint.sh server --address ":${PORT:-9000}" /data
+exec docker-entrypoint.sh server --console-address ":${PORT:-9001}" /data

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     name: data
     mountPath: /data
   envVars:
-  - key: MINIO_ACCESS_KEY
+  - key: MINIO_ROOT_USER
     generateValue: true
-  - key: MINIO_SECRET_KEY
+  - key: MINIO_ROOT_PASSWORD
     generateValue: true


### PR DESCRIPTION
The current example repo is out of date and does not work on Render.com.  This has the fixes that resolve #3 


Note, this was also reported here https://community.render.com/t/cant-deploy-render-examples-minio/2938
