### PR TITLE
Adding executable guard to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM minio/minio:latest
 
 COPY entrypoint.sh /opt/render/entrypoint.sh
+RUN chmod +x /opt/render/entrypoint.sh
 
 ENTRYPOINT ["/opt/render/entrypoint.sh"]


### PR DESCRIPTION
At least "this" user forgot to make the script executable while moving files about. For those who work with bash scripts less frequently. Again, like this user, this is a good tip picked up from https://nickjanetakis.com/blog/docker-tip-86-always-make-your-entrypoint-scripts-executable to help guard against this case.