### PR TITLE
Remove duplicate healthcheck from yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,6 @@ services:
   disk:
     name: data
     mountPath: /data
-  healthCheckPath: /minio/health/live
   envVars:
   - key: MINIO_ROOT_USER
     generateValue: true


### PR DESCRIPTION
The `healthCheckPath` property was mistakenly duplicated in the render.yaml file. This PR removes that.