### PR TITLE
Update PORT usage in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 # wrapper for docker entrypoint that takes into account the PORT env var
 
-exec docker-entrypoint.sh server --console-address ":10000" --address ":9000" /data
+exec docker-entrypoint.sh server --console-address ":$PORT" --address ":9000" /data

--- a/render.yaml
+++ b/render.yaml
@@ -14,5 +14,3 @@ services:
     generateValue: true
   - key: MINIO_ROOT_PASSWORD
     generateValue: true
-  - key: PORT
-    value: 10000


### PR DESCRIPTION
This allows the minio port to be used internally in addition to exposing the web interface as the web interface.