### PR TITLE
Create a two service setup for MinIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+### Vim template
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM minio/minio:latest
-
-COPY entrypoint.sh /opt/render/entrypoint.sh
-RUN chmod +x /opt/render/entrypoint.sh
-
-ENTRYPOINT ["/opt/render/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,24 +1,13 @@
 # MinIO on Render
 
-This template repository can be used to run [MinIO](https://min.io) on Render in a single click. It features SSD storage with automatic backups and fully managed TLS for your MinIO object store.
+This template repository can be used to run a single node [MinIO](https://min.io) server on Render in a single click. It features SSD storage with automatic backups and fully managed TLS for MinIO.
 
 Click the button below to deploy MinIO to your Render account:
 
 [![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
 
-This will create a public MinIO instance with automatically generated username and password for the web console. You can see their values under the Environment section of your Render service.
+This will create two web services:
+* A public MinIO S3-compatible API server with automatically generated username and password environment variables. This server does not include the MinIO web console, which is a separate service. Admin credentials can be found under **Environment** in the Render dashboard.
+* A web console for MinIO. You can use the username and password generated for the API server to log in, but MinIO does not recommend it for security reasons. Instead, create a new user with the [`mc`](https://min.io/docs/minio/linux/reference/minio-mc.html) CLI. You can use the instructions at https://github.com/minio/console#setup.
 
-The MinIO web console and MinIO API listen on different ports. Because Render only exposes one port publicly for Web Services, you must decide which you want to expose. By default, the console is exposed publicly. Change `PORT` to `9000` to switch to the API being exposed publicly. You can see (or modify) the console and API port definitions in this repository's `entrypoint.sh` file.
-
-## Running Locally
-
-Use the following commands to run the container locally similar to how it's run on Render.
-
-```bash
-git clone git@github.com:render-examples/minio.git
-cd minio
-docker build -t minio .
-docker run -p 9000:9000 -p 10000:10000 -v data:/data -e MINIO_ROOT_USER=admin -e MINIO_ROOT_PASSWORD=secretpwd minio
-```
-
-Then go to [http://localhost:9000](http://localhost:9000) in a browser and login with the credentials specified in the `docker run` command.
+The two services above are defined in `render.yaml` and can be customized as needed. Note that you don't need to run the console; you can deploy MinIO and interact with it using `mc`, MinIO's command line tool linked above. To do this, remove the `minio-console` web service from `render.yaml`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-# wrapper for docker entrypoint that takes into account the PORT env var
-
-exec docker-entrypoint.sh server --console-address ":$PORT" --address ":9000" /data

--- a/render.yaml
+++ b/render.yaml
@@ -17,3 +17,22 @@ services:
     generateValue: true
   - key: MINIO_BROWSER
     value: "off"
+- type: web
+  name: minio-console
+  runtime: image
+  image:
+    url: minio/console:v0.30.0
+  dockerCommand: /bin/bash -c CONSOLE_MINIO_SERVER=https://$MINIO_HOST.onrender.com ./console server --port $PORT
+  autoDeploy: false
+  envVars:
+  - key: CONSOLE_PBKDF_PASSPHRASE
+    generateValue: true
+  - key: CONSOLE_PBKDF_SALT
+    generateValue: true
+  - key: PORT
+    value: 9090
+  - key: MINIO_HOST
+    fromService:
+      name: minio-server
+      type: web
+      property: host

--- a/render.yaml
+++ b/render.yaml
@@ -1,10 +1,11 @@
 services:
 - type: web
-  name: minio
+  name: minio-server
   healthCheckPath: /minio/health/live
-  env: docker
-  dockerfilePath: ./Dockerfile
-  dockerContext: .
+  runtime: image
+  image:
+    url: docker.io/minio/minio:RELEASE.2023-08-04T17-40-21Z.hotfix.04968f7ec
+  dockerCommand: minio server /data
   autoDeploy: false
   disk:
     name: data
@@ -14,3 +15,5 @@ services:
     generateValue: true
   - key: MINIO_ROOT_PASSWORD
     generateValue: true
+  - key: MINIO_BROWSER
+    value: "off"


### PR DESCRIPTION
The console can run as a separate service now, and since Render currently exposes just one public port, it's better to run two separate web services instead. Also, the repo now uses MinIO's server and console Docker images.