### PR TITLE
Update minio to latest, use embedded console through nginx reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:stable-alpine-slim
+COPY minio-console.conf.template /etc/nginx/templates/
+RUN rm /etc/nginx/conf.d/default.conf /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh

--- a/minio-console.conf.template
+++ b/minio-console.conf.template
@@ -1,0 +1,41 @@
+upstream minio_console {
+	server ${MINIO_HOST}:${MINIO_CONSOLE_PORT};
+}
+
+server {
+	listen ${PORT};
+
+	# Allow special characters in headers
+	ignore_invalid_headers off;
+	# Allow any size file to be uploaded.
+	# Set to a value such as 1000m; to restrict file size to a specific value
+	client_max_body_size 0;
+	# Disable buffering
+	proxy_buffering off;
+	proxy_request_buffering off;
+
+	location / {
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-NginX-Proxy true;
+
+		# This is necessary to pass the correct IP to be hashed
+		real_ip_header X-Real-IP;
+
+		proxy_connect_timeout 300;
+
+		# To support websockets in MinIO versions released after January 2023
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+		# Some environments may encounter CORS errors (Kubernetes + Nginx Ingress)
+		# Uncomment the following line to set the Origin request to an empty string
+		# proxy_set_header Origin '';
+
+		chunked_transfer_encoding off;
+
+		proxy_pass http://minio_console; # This uses the upstream directive definition to load balance
+	}
+}

--- a/render.yaml
+++ b/render.yaml
@@ -4,35 +4,48 @@ services:
   healthCheckPath: /minio/health/live
   runtime: image
   image:
-    url: docker.io/minio/minio:RELEASE.2023-08-04T17-40-21Z.hotfix.04968f7ec
-  dockerCommand: minio server /data
+    url: docker.io/minio/minio:latest
+  dockerCommand: minio server /data --address $HOST:$PORT --console-address $HOST:$CONSOLE_PORT
+  # Use the following 'dockerCommand' if removing the 'minio-console'
+  # web service
+  # dockerCommand: minio server /data --address $HOST:$PORT
   autoDeploy: false
   disk:
     name: data
+    sizeGB: 5
     mountPath: /data
   envVars:
   - key: MINIO_ROOT_USER
     generateValue: true
   - key: MINIO_ROOT_PASSWORD
     generateValue: true
-  - key: MINIO_BROWSER
-    value: "off"
+  - key: HOST
+    value: "0.0.0.0"
+  - key: PORT
+    value: 9000
+  - key: CONSOLE_PORT
+    value: 9090
+  # Uncomment the following key/value pair if you are removing the
+  # 'minio-console' web service
+  # - key: MINIO_BROWSER
+  #   value: "off"
+  
+
 - type: web
   name: minio-console
-  runtime: image
-  image:
-    url: minio/console:v0.30.0
-  dockerCommand: /bin/bash -c CONSOLE_MINIO_SERVER=https://$MINIO_HOST.onrender.com ./console server --port $PORT
-  autoDeploy: false
+  runtime: docker
+  dockerContext: /
+  dockerfilePath: ./Dockerfile
   envVars:
-  - key: CONSOLE_PBKDF_PASSPHRASE
-    generateValue: true
-  - key: CONSOLE_PBKDF_SALT
-    generateValue: true
   - key: PORT
-    value: 9090
+    value: 10000
   - key: MINIO_HOST
     fromService:
       name: minio-server
       type: web
       property: host
+  - key: MINIO_CONSOLE_PORT
+    fromService:
+      name: minio-server
+      type: web
+      envVarKey: CONSOLE_PORT

--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,6 @@ services:
   autoDeploy: false
   disk:
     name: data
-    sizeGB: 5
     mountPath: /data
   envVars:
   - key: MINIO_ROOT_USER


### PR DESCRIPTION
Min.io no longer publishes a web console dockeer, and will be removing all docker-related files from the github for their console. 

Due to these changes, this update:
1. Updates minio-server to use latest Docker image, and launches embedded comsole.
2. Launches an Nginx reverse proxy using the docker runtime as a web service to access the embedded console.
