### PR TITLE
Use Chainguard MinIO image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Click the button below to deploy MinIO to your Render account:
 
 [![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
 
+The Blueprint uses the [Chainguard MinIO image](https://images.chainguard.dev/directory/image/minio/overview). Its Render startup command runs `/bin/sh -c` to create `/data` and then starts MinIO with `exec`. MinIO stores its data in `/data`, which is attached to the persistent disk.
+
 This will create two web services:
 * A public MinIO S3-compatible API server with automatically generated username and password environment variables. This server does not include the MinIO web console, which is a separate service. Admin credentials can be found under **Environment** in the Render dashboard.
 * A web console for MinIO. You can use the username and password generated for the API server to log in, but MinIO does not recommend it for security reasons. Instead, create a new user with the [`mc`](https://min.io/docs/minio/linux/reference/minio-mc.html) CLI. You can use the instructions at https://github.com/minio/console#setup.

--- a/render.yaml
+++ b/render.yaml
@@ -4,11 +4,15 @@ services:
   healthCheckPath: /minio/health/live
   runtime: image
   image:
-    url: docker.io/minio/minio:latest
-  dockerCommand: minio server /data --address $HOST:$PORT --console-address $HOST:$CONSOLE_PORT
+    url: cgr.dev/chainguard/minio
+  dockerCommand: >-
+    /bin/sh -c mkdir -p /data &&
+    exec minio server --address $HOST:$PORT --console-address $HOST:$CONSOLE_PORT /data
   # Use the following 'dockerCommand' if removing the 'minio-console'
   # web service
-  # dockerCommand: minio server /data --address $HOST:$PORT
+  # dockerCommand: >-
+  #   /bin/sh -c mkdir -p /data &&
+  #   exec minio server --address $HOST:$PORT /data
   autoDeploy: false
   disk:
     name: data


### PR DESCRIPTION
## Summary

- Switch the MinIO server to `cgr.dev/chainguard/minio`.
- Combine the Compose entrypoint and command in Render's `dockerCommand` format.
- Update the documented command variant for deployments without the separate console service.
- Preserve generated MinIO credentials and the existing persistent disk configuration.

## Why

The Chainguard image uses a different entrypoint from the official MinIO image. Passing only the MinIO server arguments on Render caused the service to exit with status 128 before MinIO emitted logs. The combined `/bin/sh -c ... && exec minio server ...` command was tested on a Render Starter service with a 10 GB persistent disk.

The service formatted the disk, passed `/minio/health/live`, and restarted successfully without reformatting the disk.

## Validation

- `render blueprints validate render.yaml -o json` returned `valid: true`.
- Live Render deployment and health check passed.
- Persistent disk restart test passed.